### PR TITLE
[FIX] Prototype pollution in "parse"

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,17 @@ function parse(string){
 	var match
 
 	for(var i = 0, len = lines.length; i !== len; i++){
-		if(match = lines[i].match(REG_GROUP))
+		if(match = lines[i].match(REG_GROUP)){
+			if (match[1] === '__proto__' || match[1] === 'constructor' || match[1] === 'prototype') {
+            	return object;
+        	}
 			object[match[1]] = group = object[match[1]] || {};
-		else if(group && (match = lines[i].match(REG_PROP)))
+		}else if(group && (match = lines[i].match(REG_PROP))){
+			if (match[1] === '__proto__' || match[1] === 'constructor' || match[1] === 'prototype') {
+            	return object;
+        	}
 			group[match[1]] = match[2];
+		}
 	}
 
 	return object;


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-ini-parser

### ⚙️ Description *

A `prototype pollution` issue occurred in the `parse` function.

### 💻 Technical Description *

I used the same fix made by `Lodash` to fix this issue in order to avoid dangerous behavior :smile:

### 🐛 Proof of Concept (PoC) *

```js
var a = require("ini-parser");
a.parse('[__proto__]\ntoString=huntr.dev');
console.log({}.toString);
```

### 🔥 Proof of Fix (PoF) *

Same PoC ... doesn't lead to `prototype` modification

### 👍 User Acceptance Testing (UAT)

All ok :smile: